### PR TITLE
Fix same document open multiple times

### DIFF
--- a/setzer/workspace/workspace.py
+++ b/setzer/workspace/workspace.py
@@ -142,7 +142,7 @@ class Workspace(Observable):
             document = BibTeXDocument()
         else:
             return None
-        document.set_filename(filename)
+        document.set_filename(os.path.realpath(filename))
         response = document.populate_from_filename()
         if response != False:
             self.add_document(document)


### PR DESCRIPTION
This fixes the option that the same document can be open multiple times.

A document can be opened multiple times by opening it via different paths with symlinks. If it is opened more than twice, the dialog "Document [...] has changed on disk. Should Setzer reload it now?" opens twice and cannot be closed.

After this fix only the real path is used when creating a document. Therefore the described bug cannot occur.